### PR TITLE
Add compatibility with newer BORIS annotation format

### DIFF
--- a/simba/third_party_label_appenders/BORIS_appender.py
+++ b/simba/third_party_label_appenders/BORIS_appender.py
@@ -12,6 +12,20 @@ from simba.utils.errors import (ThirdPartyAnnotationOverlapError,
 from simba.utils.warnings import (ThirdPartyAnnotationsOutsidePoseEstimationDataWarning,
                                   ThirdPartyAnnotationsInvalidFileFormatWarning)
 
+
+def _is_new_boris_version(pd_df: pd.DataFrame):
+    """
+    Check the format of a boris annotation file.
+
+    In the new version, additional column names are present, while
+    others have slightly different name. Here, we check for the presence
+    of a column name present only in the newer version.
+
+    :return: True if newer version
+    """
+    return 'Media file name' in list(pd_df.columns)
+
+
 class BorisAppender(ConfigReader):
 
     """
@@ -62,10 +76,20 @@ class BorisAppender(ConfigReader):
             try:
                 _, video_name, _ = get_fn_ext(file_path)
                 boris_df = pd.read_csv(file_path)
-                index = (boris_df[boris_df['Observation id'] == "Time"].index.values)
-                boris_df = pd.read_csv(file_path, skiprows=range(0, int(index + 1)))
-                boris_df = boris_df.loc[:, ~boris_df.columns.str.contains('^Unnamed')]
-                boris_df.drop(['Behavioral category', 'Comment', 'Subject'], axis=1, inplace=True)
+                if not _is_new_boris_version(boris_df):
+                    index = (boris_df[boris_df['Observation id'] == "Time"].index.values)
+                    boris_df = pd.read_csv(file_path, skiprows=range(0, int(index + 1)))
+                    boris_df = boris_df.loc[:, ~boris_df.columns.str.contains('^Unnamed')]
+                    boris_df.drop(['Behavioral category', 'Comment', 'Subject'], axis=1, inplace=True)
+                else:
+                    target_cols = ['Time', 'Media file path', 'Total length', 'FPS', 'Behavior', 'Status']
+                    boris_df.rename(columns={
+                        'Media file name': 'Media file path',
+                        'Media duration (s)': 'Total length',
+                        'Behavior type': 'Status'},
+                        inplace=True
+                    )
+                    boris_df = boris_df.reindex(columns=target_cols)
                 _, video_base_name, _ = get_fn_ext(boris_df.loc[0, 'Media file path'])
                 boris_df['Media file path'] = video_base_name
                 self.master_boris_df_list.append(boris_df)

--- a/simba/third_party_label_appenders/BORIS_appender.py
+++ b/simba/third_party_label_appenders/BORIS_appender.py
@@ -4,6 +4,7 @@ import pandas as pd
 from copy import deepcopy
 import os, glob
 from simba.mixins.config_reader import ConfigReader
+from simba.third_party_label_appenders.tools import is_new_boris_version
 from simba.utils.read_write import get_fn_ext, read_df, write_df
 from simba.utils.checks import check_if_dir_exists, check_if_filepath_list_is_empty
 from simba.utils.printing import stdout_success
@@ -11,19 +12,6 @@ from simba.utils.errors import (ThirdPartyAnnotationOverlapError,
                                 ThirdPartyAnnotationEventCountError)
 from simba.utils.warnings import (ThirdPartyAnnotationsOutsidePoseEstimationDataWarning,
                                   ThirdPartyAnnotationsInvalidFileFormatWarning)
-
-
-def _is_new_boris_version(pd_df: pd.DataFrame):
-    """
-    Check the format of a boris annotation file.
-
-    In the new version, additional column names are present, while
-    others have slightly different name. Here, we check for the presence
-    of a column name present only in the newer version.
-
-    :return: True if newer version
-    """
-    return 'Media file name' in list(pd_df.columns)
 
 
 class BorisAppender(ConfigReader):
@@ -76,7 +64,7 @@ class BorisAppender(ConfigReader):
             try:
                 _, video_name, _ = get_fn_ext(file_path)
                 boris_df = pd.read_csv(file_path)
-                if not _is_new_boris_version(boris_df):
+                if not is_new_boris_version(boris_df):
                     index = (boris_df[boris_df['Observation id'] == "Time"].index.values)
                     boris_df = pd.read_csv(file_path, skiprows=range(0, int(index + 1)))
                     boris_df = boris_df.loc[:, ~boris_df.columns.str.contains('^Unnamed')]

--- a/simba/third_party_label_appenders/tools.py
+++ b/simba/third_party_label_appenders/tools.py
@@ -30,15 +30,34 @@ def read_boris_annotation_files(data_paths: List[str],
     TIME = 'Time'
     BEHAVIOR = 'Behavior'
     STATUS = 'Status'
-    EXPECTED_HEADERS = [TIME, MEDIA_FILE_PATH, BEHAVIOR, STATUS]
+
+    def _is_new_boris_version(pd_df: pd.DataFrame):
+        """
+        Check the format of a boris annotation file.
+
+        In the new version, additional column names are present, while
+        others have slightly different name. Here, we check for the presence
+        of a column name present only in the newer version.
+
+        :return: True if newer version
+        """
+        return 'Media file name' in list(pd_df.columns)
 
     dfs = {}
     for file_cnt, file_path in enumerate(data_paths):
         _, video_name, _ = get_fn_ext(file_path)
         boris_df = pd.read_csv(file_path)
         try:
-            start_idx = (boris_df[boris_df[OBSERVATION_ID] == TIME].index.values)
-            df = pd.read_csv(file_path, skiprows=range(0, int(start_idx + 1)))[EXPECTED_HEADERS]
+            if not _is_new_boris_version(boris_df):
+                expected_headers = [TIME, MEDIA_FILE_PATH, BEHAVIOR, STATUS]
+                start_idx = (boris_df[boris_df[OBSERVATION_ID] == TIME].index.values)
+                df = pd.read_csv(file_path, skiprows=range(0, int(start_idx + 1)))[expected_headers]
+            else:
+                # Adjust column names to newer BORIS annotation format
+                MEDIA_FILE_PATH = 'Media file name'
+                STATUS = 'Behavior type'
+                expected_headers = [TIME, MEDIA_FILE_PATH, BEHAVIOR, STATUS]
+                df = pd.read_csv(file_path)[expected_headers]
             _, video_base_name, _ = get_fn_ext(df.loc[0, MEDIA_FILE_PATH])
             df.drop(MEDIA_FILE_PATH, axis=1, inplace=True)
             df.columns = ['TIME', 'BEHAVIOR', 'EVENT']

--- a/simba/third_party_label_appenders/tools.py
+++ b/simba/third_party_label_appenders/tools.py
@@ -19,6 +19,17 @@ def observer_timestamp_corrector(timestamps: List[str]) -> List[str]:
             corrected_ts.append(f'{h}:{m}:{s}.{"0" * missing_fractions}')
     return corrected_ts
 
+def is_new_boris_version(pd_df: pd.DataFrame):
+    """
+    Check the format of a boris annotation file.
+
+    In the new version, additional column names are present, while
+    others have slightly different name. Here, we check for the presence
+    of a column name present only in the newer version.
+
+    :return: True if newer version
+    """
+    return 'Media file name' in list(pd_df.columns)
 
 def read_boris_annotation_files(data_paths: List[str],
                                 error_setting: str,
@@ -31,24 +42,12 @@ def read_boris_annotation_files(data_paths: List[str],
     BEHAVIOR = 'Behavior'
     STATUS = 'Status'
 
-    def _is_new_boris_version(pd_df: pd.DataFrame):
-        """
-        Check the format of a boris annotation file.
-
-        In the new version, additional column names are present, while
-        others have slightly different name. Here, we check for the presence
-        of a column name present only in the newer version.
-
-        :return: True if newer version
-        """
-        return 'Media file name' in list(pd_df.columns)
-
     dfs = {}
     for file_cnt, file_path in enumerate(data_paths):
         _, video_name, _ = get_fn_ext(file_path)
         boris_df = pd.read_csv(file_path)
         try:
-            if not _is_new_boris_version(boris_df):
+            if not is_new_boris_version(boris_df):
                 expected_headers = [TIME, MEDIA_FILE_PATH, BEHAVIOR, STATUS]
                 start_idx = (boris_df[boris_df[OBSERVATION_ID] == TIME].index.values)
                 df = pd.read_csv(file_path, skiprows=range(0, int(start_idx + 1)))[expected_headers]


### PR DESCRIPTION
In recent BORIS versions (v8+?), the export of behavioral events in a tabular format used as annotations files in SimBA has changed. This commit thus enables SimBA to import these annotations files in a new format, while maintaining compatibility with the now-older format. I'm uncertain as to when exactly the format changed, but exporting the list of events as a tabular file in BORIS now yields a nice data frame without having to skip lines:

|Observation id|Observation date   |Description|Observation duration|Observation type|Source                              |Media duration (s)|FPS  |Subject|Behavior |Behavioral category|Behavior type|Time   |Media file name           |Image index|Image file path|Comment|
|--------------|-------------------|-----------|--------------------|----------------|------------------------------------|------------------|-----|-------|---------|-------------------|-------------|-------|--------------------------|-----------|---------------|-------|
|testobs_new   |2023-05-09 17:15:54|           |238.739             |Media file(s)   |player #&#x2060;1:videos/testExp/Video11.mp4|315.7             |59.94|       |behavior1|                   |START        |5.355  |videos/testExp/Video11.mp4|NA         |NA             |       |
|testobs_new   |2023-05-09 17:15:54|           |238.739             |Media file(s)   |player #&#x2060;1:videos/testExp/Video11.mp4|315.7             |59.94|       |behavior1|                   |STOP         |9.626  |videos/testExp/Video11.mp4|NA         |NA             |       |
|testobs_new   |2023-05-09 17:15:54|           |238.739             |Media file(s)   |player #&#x2060;1:videos/testExp/Video11.mp4|315.7             |59.94|       |behavior2|                   |START        |11.178 |videos/testExp/Video11.mp4|NA         |NA             |       |
|testobs_new   |2023-05-09 17:15:54|           |238.739             |Media file(s)   |player #&#x2060;1:videos/testExp/Video11.mp4|315.7             |59.94|       |behavior2|                   |STOP         |11.728 |videos/testExp/Video11.mp4|NA         |NA             |       |

Unfortunately, this means SimBA cannot directly import these newly-formatted files from BORIS (not without manually editing them, of course). This pull request simply enables SimBA to do just that.

This is done by adding a quick version checker seeking for the presence of a column name found only in the new format, followed by the adjustment of expected columns headers to match what SimBA is already expecting. This way, importing a BORIS annotation file that uses the now-older format should still work.

@sronilsson, I have tested using both importing ways:
- using the "Import BORIS Annotation (select folder with .csv files)" button. This does give a csv file with the behaviors appended as the last columns in `project_folder/csv/targets_inserted`. The log in the main SimBA window is:
```
Processing BORIS for 1 file(s)...
Found 3 annotated behaviors in 1 files with /home/florian/PycharmProjects/Simba/external_data/exports/mixed_observations directory
The following behavior annotations where detected in the boris directory:
behavior1
behavior2
behavior3
Appending BORIS annotations to Video11 ...
Saved BORIS annotations for video Video11...
SIMBA COMPLETE: BORIS annotations appended to dataset and saved in project_folder/csv/targets_inserted directory (elapsed time: 1.1996s)
```

- using the (newer?) "Append third-party annotations" window. This also gives a csv file with the behaviors appended as the last columns in `project_folder/csv/targets_inserted`. The log in the main SimBA window is:
```
Processing 1 BORIS file(s)...
Reading in 1 BORIS annotation files...
Processing annotations for Video11 video...
Saved BORIS annotations for video Video11...
SIMBA COMPLETE: BORIS annotations appended to dataset and saved in project_folder/csv/targets_inserted directory (elapsed time: 1.3718s)
```

I have not tested using an older BORIS format file as I do not have one with matching video and pose tracking files.

Hope this helps,